### PR TITLE
Update deprecated dependency call

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ dependencies:
 and then run
 
 ```bash
-$ crystal deps
+$ shards install
 ```
 
 ## Usage


### PR DESCRIPTION
`crystal deps` is no longer available, to install dependencies from shard, run `shards install`